### PR TITLE
Add spacy-alignments 0.8.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # rust-gnu_win-32=1.56.0 and rust_win-32=1.56.0 aren't available on win32
+  skip: True  # [py<36 or win32]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,44 +3,47 @@
 {% set version = "0.8.4" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "d4702997f459d30e537f638fbb540151adfab88aa2969f9d0db3e3ba39f47bdb"
+  sha256: d4702997f459d30e537f638fbb540151adfab88aa2969f9d0db3e3ba39f47bdb
 
 
 build:
-  number: 1
+  number: 0
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
   host:
-    - pip
     - python
+    - pip
     - setuptools
     - setuptools-rust
+    - wheel
   run:
     - python
 
 test:
-  requires:
-    - pytest
-    - hypothesis
   imports:
     - {{ module_name }}
+  requires:
+    - hypothesis >=5.3.1,<6.0.0
+    - pip
+    - pytest
   commands:
+    - pip check
     - python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Align tokenizations for spaCy + transformers
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
   # rust-gnu_win-32=1.56.0 and rust_win-32=1.56.0 aren't available on win32
   skip: True  # [py<36 or win32]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  missing_dso_whitelist:
+    - $RPATH/ld64.so.1  # [linux and s390x]
 
 requirements:
   build:


### PR DESCRIPTION
License: https://github.com/explosion/spacy-alignments/blob/v0.8.4/LICENSE
Requirements:
- https://github.com/explosion/spacy-alignments/blob/v0.8.4/pyproject.toml
- https://github.com/explosion/spacy-alignments/blob/v0.8.4/requirements.txt
- https://github.com/explosion/spacy-alignments/blob/v0.8.4/setup.cfg
- https://github.com/explosion/spacy-alignments/blob/v0.8.4/setup.py

Actions:
1. Skip `py<36 `
2. Reset build number to `0`
3. Add `wheels` in `host`
4. Update `test/requires`: `hypothesis >=5.3.1,<6.0.0`
5. Add `pip check`
6. Add `license_family`