### PR TITLE
Add spacy-alignments 0.8.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spacy-alignments" %}
 {% set module_name = "spacy_alignments" %}
-{% set version = "0.8.4" %}
+{% set version = "0.8.5" %}
 
 package:
   name: {{ name }}
@@ -8,17 +8,17 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "d4702997f459d30e537f638fbb540151adfab88aa2969f9d0db3e3ba39f47bdb"
-
+  sha256: 94ecb48f884ab8fa479d9929997281ebe0dc5b98fb8b5e53ebc252e88b023e21
 
 build:
-  number: 1
+  number: 0
+  # 2022/4/27: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename,
+  # and testing one of them fails but another succeeded.
+  skip: True  # [py<36 or win32 or (win64 and (rust_compiler == 'rust-gnu'))]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
   host:
@@ -26,21 +26,25 @@ requirements:
     - python
     - setuptools
     - setuptools-rust
+    - wheel
   run:
     - python
 
 test:
   requires:
+    - hypothesis >=5.3.1,<6.0.0
+    - pip
     - pytest
-    - hypothesis
   imports:
     - {{ module_name }}
   commands:
+    - pip check
     - python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Align tokenizations for spaCy + transformers
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
   # and testing one of them fails but another succeeded.
   skip: True  # [py<36 or win32 or (win64 and (rust_compiler == 'rust-gnu'))]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 requirements:
   build:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
License: https://github.com/explosion/spacy-alignments/blob/v0.8.5/LICENSE
Requirements:
- https://github.com/explosion/spacy-alignments/blob/v0.8.5/pyproject.toml
- https://github.com/explosion/spacy-alignments/blob/v0.8.5/requirements.txt
- https://github.com/explosion/spacy-alignments/blob/v0.8.5/setup.cfg
- https://github.com/explosion/spacy-alignments/blob/v0.8.5/setup.py

Actions:
1. Skip `py<36 `
2. Skip win32
3. Skip `(win64 and (rust_compiler == 'rust-gnu'))]`: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename, and testing one of them fails but another succeeded.
4. Reset build number to `0`
5. Add missing_dso_whitelist on s390x:
`    - $RPATH/ld64.so.1    # [s390x]`
6. Add `wheels` in `host`
7. Update `test/requires`: `hypothesis >=5.3.1,<6.0.0`
8. Add `pip check`
9. Add `license_family`